### PR TITLE
Bug fix for state.gd

### DIFF
--- a/scripts/state_machine/states/state.gd
+++ b/scripts/state_machine/states/state.gd
@@ -73,6 +73,12 @@ func handle_input(_event: InputEvent):
 func complete(params = null):
 	if delay_completion == Vector2.ZERO:
 		_enable_on_completion(params)
+	elif delay_completion.x >= 0 and delay_completion.y >= 0:
+		await _start_timer(delay_completion).timeout
+		_enable_on_completion(params)
+	else:
+		print(name, " State Node: Delay Completion values must be greater than or equal to zero.")
+		_enable_on_completion(params)
 
 func _enable_on_completion(params):
 	for state in on_completion:


### PR DESCRIPTION
I found that the "auto-advance" feature of state nodes, (where they tell the state machine what state to pick next) didn't work, if there is a non-zero delay in the state completion (delay_completion : Vector2). The issue was in state.complete() [func complete() on line 73 of state.gd]. To fix the issue, I added this code to the function, after the end of the code that is currently in that function:

elif delay_completion.x >= 0 and delay_completion.y >= 0:
	await _start_timer(delay_completion).timeout
	_enable_on_completion(params)
else:
	print(name, " State Node: Delay Completion values must be greater than or equal to zero.")
	_enable_on_completion(params)

...

A fix to a bug that causes the "auto-advance" feature of state nodes not to work when there is a non-zero Completion Delay (delay_completion : Vector2) set in the Advance properties. It also protects the timer from malfunctioning, due to a negative value in either of the vector components.